### PR TITLE
Add github-authentication

### DIFF
--- a/ome-lochy/inventory/inventory.yml
+++ b/ome-lochy/inventory/inventory.yml
@@ -32,6 +32,12 @@ k8s-cluster:
     # Doesn't work, it needs to be passed on the command line
     #kube_network_plugin: flannel
 
+    # Github authn
+    # https://github.com/oursky/kubernetes-github-authn
+    # https://raw.githubusercontent.com/oursky/kubernetes-github-authn/master/manifests/token-webhook-config.json
+    apiserver_custom_flags:
+    - "--authentication-token-webhook-config-file=/etc/kubernetes/webhooks/token-webhook-config.json"
+
 kube-node:
   hosts:
     ome-lochy-n01:

--- a/ome-lochy/kubeconfig-token-example.conf
+++ b/ome-lochy/kubeconfig-token-example.conf
@@ -1,0 +1,28 @@
+# Example kubeconfig for Github authentication
+# Replace:
+# - BASE64-ENCODED-CA-CERTIFICATE
+# - KUBERNETES-API-HOST
+# - GITHUB-PERSONAL-ACCESS-TOKEN
+
+apiVersion: v1
+kind: Config
+current-context: cluster.local
+preferences: {}
+
+clusters:
+- cluster:
+    certificate-authority-data: BASE64-ENCODED-CA-CERTIFICATE
+    server: https://KUBERNETES-API-HOST:6443
+  name: cluster.local
+
+users:
+- user:
+    token: GITHUB-PERSONAL-ACCESS-TOKEN
+    # username is automatically determined from the token
+  name: github-authn-user
+
+contexts:
+- context:
+    cluster: cluster.local
+    user: github-authn-user
+  name: cluster.local

--- a/ome-lochy/postinstall/daemonset-github-authn.yaml
+++ b/ome-lochy/postinstall/daemonset-github-authn.yaml
@@ -1,0 +1,34 @@
+# Based on https://github.com/oursky/kubernetes-github-authn/blob/b8f77f576c682689411bab82d3894969941710e4/manifests/github-authn.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: github-authn
+  name: github-authn
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: github-authn
+  template:
+    metadata:
+      labels:
+        k8s-app: github-authn
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      # TODO: Only latest is available, we should tag it ourselves
+      - image: oursky/kubernetes-github-authn
+        name: kubernetes-github-authn
+        ports:
+        - containerPort: 3000
+          hostPort: 23000
+          protocol: TCP
+      #hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      restartPolicy: Always

--- a/ome-lochy/preinstall/playbook.yml
+++ b/ome-lochy/preinstall/playbook.yml
@@ -1,0 +1,15 @@
+- hosts: kube-master
+  become: yes
+
+  tasks:
+
+  - name: Create kubernetes additional config directory
+    file:
+      path: /etc/kubernetes/webhooks
+      recurse: yes
+      state: directory
+
+  - name: Copy github-authn config file
+    copy:
+      dest: /etc/kubernetes/webhooks/token-webhook-config.json
+      src: token-webhook-config.json

--- a/ome-lochy/preinstall/token-webhook-config.json
+++ b/ome-lochy/preinstall/token-webhook-config.json
@@ -1,0 +1,31 @@
+{
+    "kind": "Config",
+    "apiVersion": "v1",
+    "preferences": {},
+    "clusters": [
+        {
+            "name": "github-authn",
+            "cluster": {
+                "server": "http://localhost:23000/authenticate"
+            }
+        }
+    ],
+    "users": [
+        {
+            "name": "authn-apiserver",
+            "user": {
+                "token": "secret"
+            }
+        }
+    ],
+    "contexts": [
+        {
+            "name": "webhook",
+            "context": {
+                "cluster": "github-authn",
+                "user": "authn-apiserver"
+            }
+        }
+    ],
+    "current-context": "webhook"
+}

--- a/ome-lochy/run-ansible.sh
+++ b/ome-lochy/run-ansible.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+
+export ANSIBLE_HOST_KEY_CHECKING=False
+ANSIBLE_ARGS="-i ./inventory --become --ask-become-pass --diff"
+EXTRA_VARS='{"helm_enabled":true, "kube_network_plugin":"flannel"}'
+
+if [ $# -gt 0 ]; then
+    ansible-playbook $ANSIBLE_ARGS -e "$EXTRA_VARS" "$@"
+else
+    ansible-playbook $ANSIBLE_ARGS -e "$EXTRA_VARS" preinstall/playbook.yml kubespray/cluster.yml
+fi


### PR DESCRIPTION
Adds the helper service from https://github.com/oursky/kubernetes-github-authn to allow users to be identified by GitHub.

You'll need to bind users to a role/clusterrole (either pre-existing or new) for this to be any use, e.g.

- `kubectl create clusterrolebinding <USERNAME>-admin-binding --clusterrole=cluster-admin --user=<USERNAME>`
- `kubectl create rolebinding <USERNAME>-binding --clusterrole=admin --user=<USERNAME> --namespace test`