### PR TITLE
Install helm 2.12.2

### DIFF
--- a/ome-lochy/postinstall/install-helm.sh
+++ b/ome-lochy/postinstall/install-helm.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Install and secure access to Helm
+set -eu
+
+VERSION=2.12.2
+
+PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
+curl -L https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION}-${PLATFORM}-amd64.tar.gz | tar -x -
+
+echo '{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"name": "tiller"}}' | kubectl apply -n kube-system -f -
+echo '{"apiVersion": "rbac.authorization.k8s.io/v1","kind": "ClusterRoleBinding","metadata":{"name":"tiller"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind": "ClusterRole","name": "cluster-admin"},"subjects":[{"kind": "ServiceAccount","name": "tiller","namespace": "kube-system"}]}' | kubectl apply -n kube-system -f -
+
+${PLATFORM}-amd64/helm init --upgrade --service-account tiller
+
+# https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8209ea252a1ec2cdb90640ea2a2735467b4aadbc/doc/source/security.md#secure-access-to-helm
+kubectl --namespace=kube-system patch deployment tiller-deploy --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'

--- a/ome-lochy/postinstall/reduce-helm-privileges.sh
+++ b/ome-lochy/postinstall/reduce-helm-privileges.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-# https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/v0.6/doc/source/security.md#secure-access-to-helm
-
-set -eu
-
-kubectl --namespace=kube-system patch deployment tiller-deploy --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
-kubectl -n kube-system delete service tiller-deploy


### PR DESCRIPTION
Full helm installation/setup script.

```
$ export KUBECONFIG=<path/to/kubeconfig>

$ ./install-helm.sh

serviceaccount/tiller configured
clusterrolebinding.rbac.authorization.k8s.io/tiller configured

Tiller (the Helm server-side component) has been upgraded to the current version.
Happy Helming!
deployment.extensions/tiller-deploy patched (no change)
```